### PR TITLE
Fix bug: Incorrect horizontal padding of code block

### DIFF
--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -12,7 +12,7 @@ div.highlighter-rouge {
 }
 
 div.highlight {
-	padding: 30px 7.5vw;
+	padding: 30px 150px;
 }
 
 pre.highlight, code {

--- a/_sass/theme.scss
+++ b/_sass/theme.scss
@@ -104,29 +104,41 @@ header {
 
 	@media screen and  (max-width: $mobileWidth) {
 		margin:0 15px; 
-		.highlighter-rouge {
+		div.highlighter-rouge {
 			right: 15px;
+		}
+		div.highlight {
+			padding: 30px 15px;
 		}
 	}
 
 	@media screen and (max-width: $tabWidth) and (min-width: $mobileWidth){
 		margin:0 40px;	
-		.highlighter-rouge {
+		div.highlighter-rouge {
 			right: 40px;
+		}
+		div.highlight {
+			padding: 30px 40px;
 		}
 	}
 
 	@media screen and (max-width: $desktopWidth) and (min-width: $tabWidth){
 		margin:0 80px;
-		.highlighter-rouge {
+		div.highlighter-rouge {
 			right: 80px;
+		}
+		div.highlight {
+			padding: 30px 80px;
 		}
 	}
 
 	@media screen and (min-width: $desktopWidth) and (max-width: 1280px) {
 		margin:0 100px;
-		.highlighter-rouge {
+		div.highlighter-rouge {
 			right: 100px;
+		}
+		div.highlight {
+			padding: 30px 100px;
 		}
 	}
 }


### PR DESCRIPTION
When windows width varies, the horizontal padding of the code block doesn't look right.

Align code block with other paragraphs