### PR TITLE
Added MathJax Support

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,6 +28,8 @@
 <script src="{{ "/assets/js/picker.js" | relative_url }}"></script>
 {%- endif -%}
 
+{%- if site.texture.useMathJax -%}
 <script type="text/javascript"
   src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
+{%- endif -%}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,3 +27,7 @@
 </div>
 <script src="{{ "/assets/js/picker.js" | relative_url }}"></script>
 {%- endif -%}
+
+<script type="text/javascript"
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>


### PR DESCRIPTION
This addition loads MathJax from a cdn, allowing the addition of LaTeX equations to pages and posts.

A demonstration post can be found [here](https://www.noahpaladino.com/blog/2019/11/04/whales.html).