### PR TITLE
Fix overflow-x issue for coding posts

### DIFF
--- a/_sass/_begin.scss
+++ b/_sass/_begin.scss
@@ -13,6 +13,10 @@ img, embed, object, video {
 	max-width: 100%;
 }
 
+main {
+	overflow-x: hidden;
+}
+
 //
 // Fluid Typography
 //


### PR DESCRIPTION
#### Bug

Due to the browser vertical scrollbar, having `100vw` for the coding posts can cause a horizontal overflow and horizontal scrollbar for posts that have a coding section like this [demo article](https://thelehhman.com/texture/posts/coding-post/)

#### Fix

`overflow-x: hidden on <main>`
 Because `div.highlighter.rouge` does not have a parent with `width: 100%` a conventional solution would involve using *hacky* code as presented in this [article](https://css-tricks.com/full-width-containers-limited-width-parents/)
Unless, you would prefer a structural change in the code of this project I think my solution is sufficient and to my knowledge does not present any additional issues.
