### PR TITLE
Fix so that navbar doesn't jump horizontally when scrollbar appears

### DIFF
--- a/_sass/theme.scss
+++ b/_sass/theme.scss
@@ -16,6 +16,10 @@ $lightGray: #eee;
 	box-sizing: border-box;
 }
 
+html {
+  overflow-y: scroll;
+}
+
 body {
 	font-family: 'Nunito Sans', sans-serif;
 	@include fluidType(16px, 19px);


### PR DESCRIPTION
Fix so that navbar doesn't jump horizontally when scroll bar appears and disappears, as seen in [this](https://streamable.com/np21wk) video clip. 