### PR TITLE
fix date_format to refer site.texture.date_format as intended

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,7 +5,7 @@ layout: page
 <ul class="posts">
 	{%- for post in site.posts -%}
 	<li>
-		{%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+		{%- assign date_format = site.texture.date_format | default: "%b %-d, %Y" -%}
 		<div class="post-meta">
 			<a class="post-link" href="{{ post.url | relative_url }}">
 				<h2 class="post-title">{{ post.title | escape }}</h2>


### PR DESCRIPTION
This Pull Request fixes date_format to refer site.texture.date_format as intended

On current version, this line on _config.yml does not work as intended.
```
texture:
  date_format: "[whatever]"
```
Instead this works.
```
minima:
  date_format: "[whatever]"
```